### PR TITLE
Ensure the generated dev dependencies work in current Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ debian/%.deb: debian/%/DEBIAN/control debian/$$*/usr/lib/$$*.so
 debian/%-dev/DEBIAN/control: debian/$$*/usr/lib/$$*.so debian/control $$(SYMBOLS)
 	@mkdir -p $(@D)
 	echo Architecture: $$(dpkg --print-architecture) > $@
-	echo Depends: '$* (= $(VERSION)), ' $$(dpkg-shlibdeps -O -xlibstdc++6 --warnings=0  $< | sed -e s/shlibs:Depends=// -e 's/\([^ ^,]\+\)\([^,]*\)/\1-dev\2/g' -e s/libpulse0-dev/libpulse-dev/ -e 's/libssl\S\+/libssl-dev/') >> $@
+	echo Depends: '$* (= $(VERSION)), ' $$(dpkg-shlibdeps -O -xlibstdc++6 --warnings=0  $< | sed -e s/shlibs:Depends=// -e 's/\([^ ^,]\+\)\([^,]*\)/\1-dev\2/g' -e s/libpulse0-dev/libpulse-dev/ -e 's/libssl\S\+/libssl-dev/') | sed 's/,*$//g' >> $@
 	echo Description: 'AWS C++ SDK headers' >> $@
 	echo Maintainer: 'Lucid Software <ops@lucidchart.com>' >> $@
 	echo Package: $*-dev >> $@

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ debian/%.deb: debian/%/DEBIAN/control debian/$$*/usr/lib/$$*.so
 debian/%-dev/DEBIAN/control: debian/$$*/usr/lib/$$*.so debian/control $$(SYMBOLS)
 	@mkdir -p $(@D)
 	echo Architecture: $$(dpkg --print-architecture) > $@
-	echo Depends: '$* (= $(VERSION)), ' $$(dpkg-shlibdeps -O -xlibstdc++6 --warnings=0  $< | sed -e s/shlibs:Depends=// -e 's/\([^ ^,]\+\)\([^,]*\)/\1-dev\2/g' -e s/libpulse0-dev/libpulse-dev/ -e 's/libssl\S\+/libssl-dev/') | sed 's/,*$//g' >> $@
+	echo Depends: '$* (= $(VERSION)), ' $$(dpkg-shlibdeps -O -xlibstdc++6 --warnings=0  $< | sed -e s/shlibs:Depends=// -e 's/\([^ ^,]\+\)\([^,]*\)/\1-dev\2/g' -e s/libpulse0-dev/libpulse-dev/ -e 's/libssl\S\+/libssl-dev/' -e 's/libcurl3-gnutls-dev/libcurl4-gnutls-dev/' -e 's/libgcc1-dev (>= 1:/libgcc-6-dev (>= /') | sed 's/,*$$//g' >> $@
 	echo Description: 'AWS C++ SDK headers' >> $@
 	echo Maintainer: 'Lucid Software <ops@lucidchart.com>' >> $@
 	echo Package: $*-dev >> $@


### PR DESCRIPTION
This PR provides two small fixes for #5 and #8 to make sure the generated `Depends` field for dev packages works in the current Debian.

Note that since the list of packages that need to be overridden seems to be increasing, it might be a good idea to introduce a file where these overrides are explicitly defined, i.e., something similar to a `pydist-overrides` file used by `dh_python`. However, this patch should make sure that the library works until something like that is implemented.